### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/azure-spring-apps-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/config/ConfigurationPrompter.java
+++ b/azure-spring-apps-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/config/ConfigurationPrompter.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.maven.springcloud.config;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.fge.jackson.JsonLoader;
+import com.microsoft.azure.maven.prompt.DefaultPrompter;
+import com.microsoft.azure.maven.prompt.IPrompter;
+import com.microsoft.azure.maven.prompt.InputValidateResult;
+import com.microsoft.azure.maven.prompt.SchemaValidator;
+import com.microsoft.azure.toolkit.lib.common.utils.TextUtils;
+import com.microsoft.azure.maven.utils.TemplateUtils;
+
+import com.microsoft.azure.toolkit.lib.common.exception.InvalidConfigurationException;
+import lombok.Lombok;
+import org.apache.commons.collections4.IteratorUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.plugin.logging.Log;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class ConfigurationPrompter {
+    private final ExpressionEvaluator expressionEvaluator;
+    private IPrompter prompt;
+    private Map<String, Map<String, Object>> templates;
+    private Map<String, Object> commonVariables;
+    private SchemaValidator validator;
+    private final Log log;
+
+    public ConfigurationPrompter(ExpressionEvaluator expressionEvaluator, Log log) {
+        this.expressionEvaluator = expressionEvaluator;
+        this.log = log;
+    }
+
+    public void initialize() throws IOException, InvalidConfigurationException {
+        prompt = new DefaultPrompter();
+        validator = new SchemaValidator();
+        templates = new HashMap<>();
+        commonVariables = new HashMap<>();
+        final Yaml yaml = new Yaml();
+        final Set<String> resourceNames = new HashSet<>();
+        try (final InputStream inputStream = this.getClass().getResourceAsStream("/MessageTemplates.yaml")) {
+            final Iterable<Object> rules = yaml.loadAll(inputStream);
+
+            for (final Object rule : rules) {
+                final Map<String, Object> map = (Map<String, Object>) rule;
+                templates.put((String) map.get("id"), map);
+                if (map.containsKey("resource")) {
+                    resourceNames.add((String) map.get("resource"));
+                }
+            }
+        }
+        for (final String resourceName : resourceNames) {
+            final ObjectNode resourceSchema = (ObjectNode) JsonLoader.fromResource("/schema/" + resourceName + ".json");
+            if (!resourceSchema.has("properties")) {
+                throw new InvalidConfigurationException(String.format("Bad schema for %s: missing properties field.", resourceName));
+            }
+            final ObjectNode propertiesNode = (ObjectNode) resourceSchema.get("properties");
+            IteratorUtils.forEach(propertiesNode.fields(), prop -> {
+                try {
+                    this.validator.collectSingleProperty(resourceName, prop.getKey(), prop.getValue());
+                } catch (JsonProcessingException e) {
+                    throw Lombok.sneakyThrow(e);
+                }
+            });
+        }
+
+    }
+
+    public void putCommonVariable(String key, Object obj) {
+        this.commonVariables.put(key, obj);
+    }
+
+    public <T> T handleSelectOne(String templateId, List<T> options, T defaultEntity, Function<T, String> getNameFunc)
+            throws IOException, InvalidConfigurationException {
+        final Map<String, Object> variables = createVariableTables(templateId);
+        final boolean isRequired = TemplateUtils.evalBoolean("required", variables);
+        if (options.size() == 0) {
+            if (isRequired) {
+                throw new InvalidConfigurationException(TemplateUtils.evalText("message.empty_options", variables));
+            }
+            final String warningMessage = TemplateUtils.evalText("message.empty_options", variables);
+            if (StringUtils.isNotBlank(warningMessage)) {
+                log.warn(warningMessage);
+            }
+            return null;
+        }
+        final boolean autoSelect = TemplateUtils.evalBoolean("auto_select", variables);
+        if (options.size() == 1) {
+            if (autoSelect) {
+                log.info(TemplateUtils.evalText("message.auto_select", variables));
+                return options.get(0);
+            }
+            if (!this.prompt.promoteYesNo(TemplateUtils.evalText("promote.one", variables),
+                    /*
+                     * if only one options is available, when it is required, select it by default
+                     */
+                    isRequired, isRequired)) {
+                if (isRequired) {
+                    throw new InvalidConfigurationException(TemplateUtils.evalText("message.select_none", variables));
+                }
+                return null;
+            }
+            return options.get(0);
+        }
+        if (defaultEntity == null && variables.containsKey("default_index")) {
+            defaultEntity = options.get((Integer) variables.get("default_index"));
+        }
+        return prompt.promoteSingleEntity(TemplateUtils.evalText("promote.header", variables), TemplateUtils.evalText("promote.many", variables),
+                options, defaultEntity, getNameFunc, isRequired);
+    }
+
+    public <T> List<T> handleMultipleCase(String templateId, List<T> options, Function<T, String> getNameFunc)
+        throws IOException, InvalidConfigurationException {
+        final Map<String, Object> variables = createVariableTables(templateId);
+        final boolean allowEmpty = TemplateUtils.evalBoolean("allow_empty", variables);
+        if (options.size() == 0) {
+            if (!allowEmpty) {
+                throw new InvalidConfigurationException(TemplateUtils.evalText("message.empty_options", variables));
+            } else {
+                final String warningMessage = TemplateUtils.evalText("message.empty_options", variables);
+                if (StringUtils.isNotBlank(warningMessage)) {
+                    log.warn(warningMessage);
+                }
+            }
+            return options;
+        }
+        final boolean autoSelect = TemplateUtils.evalBoolean("auto_select", variables);
+        final boolean defaultSelected = TemplateUtils.evalBoolean("default_selected", variables);
+        if (options.size() == 1) {
+            if (autoSelect) {
+                log.info(TemplateUtils.evalText("message.auto_select", variables));
+                return options;
+            } else {
+                if (!this.prompt.promoteYesNo(TemplateUtils.evalText("promote.one", variables), defaultSelected, false)) {
+                    // user cancels
+                    final String warningMessage = TemplateUtils.evalText("message.select_none", variables);
+                    if (StringUtils.isNotBlank(warningMessage)) {
+                        log.warn(warningMessage);
+                    }
+                    return Collections.emptyList();
+                }
+                return options;
+            }
+        }
+        final List<T> selectedEntities = prompt.promoteMultipleEntities(TemplateUtils.evalText("promote.header", variables),
+                TemplateUtils.evalText("promote.many", variables), TemplateUtils.evalText("promote.header", variables), options, getNameFunc,
+                allowEmpty, defaultSelected ? "to select ALL" : "to select NONE", defaultSelected ? options : Collections.emptyList());
+        if (selectedEntities.isEmpty()) {
+            final String warningMessage = TemplateUtils.evalText("message.select_none", variables);
+            if (StringUtils.isNotBlank(warningMessage)) {
+                log.warn(warningMessage);
+            }
+        }
+        return selectedEntities;
+    }
+
+    public String handle(String templateId, boolean autoApplyDefault)
+            throws InvalidConfigurationException, IOException {
+        return handle(templateId, autoApplyDefault, null);
+    }
+
+    public String handle(String templateId, boolean autoApplyDefault, Object cliParameter)
+            throws InvalidConfigurationException, IOException {
+        final Map<String, Object> variables = createVariableTables(templateId);
+        final String resourceName = (String) variables.get("resource");
+
+        final String propertyName = (String) variables.get("property");
+        if (StringUtils.isBlank(propertyName)) {
+            throw new InvalidConfigurationException("Cannot find property in template: " + templateId);
+        }
+        if (StringUtils.isBlank(resourceName)) {
+            throw new InvalidConfigurationException("Cannot find resource in template: " + templateId);
+        }
+        final Map<String, Object> schema = validator.getSchemaMap(resourceName, propertyName);
+        variables.put("schema", schema);
+        Object defaultObj = variables.get("default");
+        if (defaultObj instanceof String) {
+            defaultObj = TemplateUtils.evalPlainText("default", variables);
+        } else {
+            if (defaultObj == null) {
+                defaultObj = schema.get("default");
+            }
+        }
+        final String defaultObjectStr = Objects.toString(defaultObj, null);
+        final String type = (String) schema.get("type");
+
+        if (cliParameter != null) {
+            // valid against the property from cli parameter, if it passes, then we skip the configuration
+            final String errorMessage = validator.validateSingleProperty(resourceName, propertyName, cliParameter.toString());
+            if (errorMessage == null) {
+                return cliParameter.toString();
+            }
+            System.out.println(
+                    TextUtils.yellow(String.format("Validation failure for %s[%s]: %s", propertyName, cliParameter, errorMessage)));
+        }
+
+        if (autoApplyDefault) {
+            if (defaultObj != null) {
+                // we need to check default value
+                final String errorMessage = validator.validateSingleProperty(resourceName, propertyName, defaultObjectStr);
+                if (errorMessage == null) {
+                    return defaultObjectStr;
+                }
+                throw new InvalidConfigurationException(
+                        String.format("Default value '%s' cannot be applied to %s due to error: %s", defaultObjectStr, propertyName, errorMessage));
+            }
+
+            return null;
+        }
+
+        final String promoteMessage = TemplateUtils.evalText("promote", variables);
+        return prompt.promoteString(promoteMessage, Objects.toString(defaultObj, null), input -> {
+            if ("boolean".equals(type)) {
+                // convert user input from y to true and N to false
+                if (input.equalsIgnoreCase("Y")) {
+                    input = "true";
+                }
+                if (input.equalsIgnoreCase("N")) {
+                    input = "false";
+                }
+            }
+            final String value;
+            try {
+                value = evaluateMavenExpression(input);
+                if (value == null) {
+                    return InputValidateResult.error(String.format("Cannot evaluate maven expression: %s", input));
+                }
+            } catch (ExpressionEvaluationException e) {
+                return InputValidateResult.error(e.getMessage());
+            }
+
+            final String errorMessage = validator.validateSingleProperty(resourceName, propertyName, value);
+            return errorMessage == null ? InputValidateResult.wrap(input) : InputValidateResult.error(errorMessage);
+
+        }, TemplateUtils.evalBoolean("required", variables));
+    }
+
+    public void confirmChanges(Map<String, String> changesToConfirm, Supplier<Integer> confirmedAction) throws IOException {
+        final Map<String, Object> variables = createVariableTables("confirm");
+        System.out.println(TemplateUtils.evalText("promote.header", variables));
+        for (final Map.Entry<String, String> entry : changesToConfirm.entrySet()) {
+            if (StringUtils.isNotBlank(entry.getValue())) {
+                printConfirmation(entry.getKey(), entry.getValue());
+            }
+        }
+
+        final Boolean userConfirm = prompt.promoteYesNo(TemplateUtils.evalText("promote.footer", variables),
+                TemplateUtils.evalBoolean("default", variables), TemplateUtils.evalBoolean("required", variables));
+        if (userConfirm == null || !userConfirm) {
+            log.info(TemplateUtils.evalText("message.skip", variables));
+            return;
+        }
+        final Integer appliedCount = confirmedAction.get();
+        if (appliedCount == null || appliedCount == 0) {
+            log.info(TemplateUtils.evalText("message.none", variables));
+        } else if (appliedCount == 1) {
+            log.info(TemplateUtils.evalText("message.one", variables));
+        } else {
+            log.info(TemplateUtils.evalText("message.many", variables));
+        }
+    }
+
+    public void close() throws IOException {
+        this.prompt.close();
+    }
+
+    private Map<String, Object> createVariableTables(String templateId) {
+        final Map<String, Object> variables = templates.get(templateId);
+        if (variables == null) {
+            throw new IllegalArgumentException("Cannot find template: " + templateId);
+        }
+        variables.putAll(this.commonVariables);
+        return variables;
+    }
+
+    private String evaluateMavenExpression(String input) throws ExpressionEvaluationException {
+        if (input != null && input.contains("${")) {
+            return (String) expressionEvaluator.evaluate(input);
+        }
+        return input;
+    }
+
+    private static void printConfirmation(String key, Object value) {
+        System.out.printf("%-17s : %s%n", key, TextUtils.cyan(Objects.toString(value)));
+    }
+}

--- a/azure-toolkit-libs/azure-toolkit-database-lib/src/main/java/com/microsoft/azure/toolkit/lib/database/JdbcUrl.java
+++ b/azure-toolkit-libs/azure-toolkit-database-lib/src/main/java/com/microsoft/azure/toolkit/lib/database/JdbcUrl.java
@@ -11,6 +11,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
@@ -20,13 +22,15 @@ import java.util.Objects;
 public abstract class JdbcUrl {
 
     private static final int MYSQL_DEFAULT_PORT = 3306;
+    private static final int POSTGRE_SQL_DEFAULT_PORT = 5432;
     private static final int SQL_SERVER_DEFAULT_PORT = 1433;
 
+    @Nonnull
     protected final URIBuilder uri;
     private String username;
     private String password;
 
-    private JdbcUrl(String url) {
+    private JdbcUrl(@Nonnull String url) {
         Preconditions.checkArgument(StringUtils.startsWith(url, "jdbc:"), "invalid jdbc url.");
         try {
             this.uri = new URIBuilder(url.substring(5));
@@ -35,36 +39,53 @@ public abstract class JdbcUrl {
         }
     }
 
-    public static JdbcUrl from(String connectionString) {
+    @Nonnull
+    public static JdbcUrl from(@Nonnull String connectionString) {
         if (StringUtils.startsWith(connectionString, "jdbc:mysql:")) {
             return new MySQLJdbcUrl(connectionString);
         } else if (StringUtils.startsWith(connectionString, "jdbc:sqlserver:")) {
             return new SQLServerJdbcUrl(connectionString);
+        } else if (StringUtils.startsWith(connectionString, "jdbc:postgresql:")) {
+            return new PostgreSQLJdbcUrl(connectionString);
         }
         throw new AzureToolkitRuntimeException("Unsupported jdbc url: %s", connectionString);
     }
 
-    public static JdbcUrl mysql(String serverHost, String database) {
+    @Nonnull
+    public static JdbcUrl mysql(@Nonnull String serverHost, @Nonnull String database) {
         return new MySQLJdbcUrl(String.format("jdbc:mysql://%s:%s/%s?serverTimezone=UTC&useSSL=true&requireSSL=false",
             encode(serverHost), MYSQL_DEFAULT_PORT, encode(database)));
     }
 
-    public static JdbcUrl mysql(String serverHost) {
+    @Nonnull
+    public static JdbcUrl mysql(@Nonnull String serverHost) {
         return new MySQLJdbcUrl(String.format("jdbc:mysql://%s:%s?serverTimezone=UTC&useSSL=true&requireSSL=false",
             encode(serverHost), MYSQL_DEFAULT_PORT));
     }
 
-    public static JdbcUrl sqlserver(String serverHost, String database) {
+    @Nonnull
+    public static JdbcUrl postgre(@Nonnull String serverHost, @Nonnull String database) {
+        // Postgre database name is required;
+        return new PostgreSQLJdbcUrl(String.format("jdbc:postgresql://%s:%s/%s?ssl=true&sslmode=require",
+            encode(serverHost), POSTGRE_SQL_DEFAULT_PORT, encode(database)));
+    }
+
+    @Nonnull
+    public static JdbcUrl sqlserver(@Nonnull String serverHost, @Nonnull String database) {
         return new SQLServerJdbcUrl(String.format("jdbc:sqlserver://%s:%s;encrypt=true;trustServerCertificate=false;loginTimeout=30;database=%s;",
             encode(serverHost), SQL_SERVER_DEFAULT_PORT, encode(database)));
     }
 
-    public static JdbcUrl sqlserver(String serverHost) {
+    @Nonnull
+    public static JdbcUrl sqlserver(@Nonnull String serverHost) {
         return new SQLServerJdbcUrl(String.format("jdbc:sqlserver://%s:%s;encrypt=true;trustServerCertificate=false;loginTimeout=30;",
             encode(serverHost), SQL_SERVER_DEFAULT_PORT));
     }
 
     abstract int getDefaultPort();
+
+    @Nonnull
+    public abstract String getDefaultDriverClass();
 
     public int getPort() {
         if (this.uri.getPort() >= 0) {
@@ -78,6 +99,7 @@ public abstract class JdbcUrl {
         return decode(this.uri.getHost());
     }
 
+    @Nullable
     public String getDatabase() {
         final String path = this.uri.getPath();
         return decode(StringUtils.startsWith(path, "/") ? path.substring(1) : path);
@@ -91,26 +113,31 @@ public abstract class JdbcUrl {
         return password;
     }
 
+    @Nonnull
     public JdbcUrl setServerHost(String serverHost) {
         this.uri.setHost(serverHost);
         return this;
     }
 
+    @Nonnull
     public JdbcUrl setDatabase(String database) {
         this.uri.setPath("/" + database);
         return this;
     }
 
+    @Nonnull
     public JdbcUrl setUsername(String username) {
         this.username = username;
         return this;
     }
 
+    @Nonnull
     public JdbcUrl setPassword(String password) {
         this.password = password;
         return this;
     }
 
+    @Nonnull
     public JdbcUrl setPort(int port) {
         this.uri.setPort(port);
         return this;
@@ -118,11 +145,11 @@ public abstract class JdbcUrl {
 
     @Override
     public String toString() {
-        String url = "jdbc:" + uri.toString();
+        String url = "jdbc:" + uri;
         return decode(url);
     }
 
-    private static String encode(String context) {
+    private static String encode(@Nonnull String context) {
         try {
             return URLEncoder.encode(context, "UTF-8");
         } catch (UnsupportedEncodingException e) {
@@ -130,7 +157,7 @@ public abstract class JdbcUrl {
         }
     }
 
-    private static String decode(String context) {
+    private static String decode(@Nonnull String context) {
         try {
             return URLDecoder.decode(context, "UTF-8");
         } catch (UnsupportedEncodingException e) {
@@ -139,7 +166,7 @@ public abstract class JdbcUrl {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }
@@ -157,7 +184,7 @@ public abstract class JdbcUrl {
 
     private static class MySQLJdbcUrl extends JdbcUrl {
 
-        private MySQLJdbcUrl(String url) {
+        private MySQLJdbcUrl(@Nonnull String url) {
             super(url);
         }
 
@@ -166,6 +193,29 @@ public abstract class JdbcUrl {
             return MYSQL_DEFAULT_PORT;
         }
 
+        @Nonnull
+        @Override
+        public String getDefaultDriverClass() {
+            return "com.mysql.cj.jdbc.Driver";
+        }
+    }
+
+    private static class PostgreSQLJdbcUrl extends JdbcUrl {
+
+        private PostgreSQLJdbcUrl(@Nonnull String url) {
+            super(url);
+        }
+
+        @Override
+        int getDefaultPort() {
+            return POSTGRE_SQL_DEFAULT_PORT;
+        }
+
+        @Nonnull
+        @Override
+        public String getDefaultDriverClass() {
+            return "org.postgresql.Driver";
+        }
     }
 
     private static class SQLServerJdbcUrl extends JdbcUrl {
@@ -179,16 +229,24 @@ public abstract class JdbcUrl {
             return SQL_SERVER_DEFAULT_PORT;
         }
 
+        @Nonnull
+        @Override
+        public String getDefaultDriverClass() {
+            return "com.microsoft.sqlserver.jdbc.SQLServerDriver";
+        }
+
+        @Nonnull
         @Override
         public JdbcUrl setDatabase(String database) {
             this.uri.setParameter("database", database);
             return this;
         }
 
+        @Nullable
         @Override
         public String getDatabase() {
             return this.uri.getQueryParams().stream().filter(e -> StringUtils.equals(e.getName(), "database"))
-                    .map(NameValuePair::getValue).findFirst().orElse(null);
+                .map(NameValuePair::getValue).findFirst().orElse(null);
         }
 
         @Override


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:1957874817 -->
<!-- fingerprint:1229711504 -->
<!-- fingerprint:-768059664 -->
<!-- fingerprint:-820559842 -->
<!-- fingerprint:784823622 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (5)
